### PR TITLE
feat: Implement Razorpay and Stripe payment gateway logic

### DIFF
--- a/multi-payment-gateway/pom.xml
+++ b/multi-payment-gateway/pom.xml
@@ -47,6 +47,20 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
+		<!-- Stripe SDK -->
+		<dependency>
+			<groupId>com.stripe</groupId>
+			<artifactId>stripe-java</artifactId>
+			<version>24.0.0</version> <!-- Use a recent stable version -->
+		</dependency>
+
+		<!-- Razorpay SDK -->
+		<dependency>
+			<groupId>com.razorpay</groupId>
+			<artifactId>razorpay-java</artifactId>
+			<version>1.4.3</version> <!-- Use a recent stable version -->
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>

--- a/src/main/java/com/example/multipaymentgateway/model/Payment.java
+++ b/src/main/java/com/example/multipaymentgateway/model/Payment.java
@@ -1,0 +1,55 @@
+package com.example.multipaymentgateway.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "payments")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, updatable = false)
+    private String transactionId; // Our system's unique transaction ID
+
+    private String gatewayTransactionId; // Transaction ID from the payment gateway
+
+    @Column(nullable = false)
+    private String paymentGateway; // e.g., "stripe", "razorpay"
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Column(nullable = false)
+    private String currency;
+
+    @Column(nullable = false)
+    private String status; // e.g., "PENDING", "SUCCESS", "FAILED", "REFUNDED"
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/example/multipaymentgateway/repository/PaymentRepository.java
+++ b/src/main/java/com/example/multipaymentgateway/repository/PaymentRepository.java
@@ -1,0 +1,14 @@
+package com.example.multipaymentgateway.repository;
+
+import com.example.multipaymentgateway.model.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    Optional<Payment> findByTransactionId(String transactionId);
+    Optional<Payment> findByGatewayTransactionId(String gatewayTransactionId); // Added for flexibility
+}

--- a/src/main/java/com/example/multipaymentgateway/service/RazorpayService.java
+++ b/src/main/java/com/example/multipaymentgateway/service/RazorpayService.java
@@ -2,50 +2,320 @@ package com.example.multipaymentgateway.service;
 
 import com.example.multipaymentgateway.dto.PaymentRequest;
 import com.example.multipaymentgateway.dto.PaymentResponse;
+import com.example.multipaymentgateway.exception.PaymentProcessingException;
+import com.example.multipaymentgateway.model.Payment;
+import com.example.multipaymentgateway.repository.PaymentRepository;
+import com.razorpay.Order;
+import com.razorpay.RazorpayClient;
+import com.razorpay.RazorpayException;
+import com.razorpay.Refund;
+import jakarta.annotation.PostConstruct;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service("razorpayService")
 public class RazorpayService implements PaymentGateway {
 
+    private static final Logger logger = LoggerFactory.getLogger(RazorpayService.class);
+
+    @Value("${razorpay.api.key}")
+    private String razorpayKeyId;
+
+    @Value("${razorpay.api.secret}")
+    private String razorpayKeySecret;
+
+    private RazorpayClient razorpayClient;
+    private final PaymentRepository paymentRepository;
+
+    public RazorpayService(PaymentRepository paymentRepository) {
+        this.paymentRepository = paymentRepository;
+    }
+
+    @PostConstruct
+    public void init() {
+        try {
+            // Ensure keys are not null or empty before initializing
+            if (razorpayKeyId == null || razorpayKeyId.isEmpty() || razorpayKeyId.equals("YOUR_RAZORPAY_KEY_ID") ||
+                razorpayKeySecret == null || razorpayKeySecret.isEmpty() || razorpayKeySecret.equals("YOUR_RAZORPAY_KEY_SECRET")) {
+                logger.warn("Razorpay API Key ID or Secret is not configured or using default placeholders. Razorpay client will not be initialized.");
+                return; // Do not initialize if keys are placeholders or missing
+            }
+            this.razorpayClient = new RazorpayClient(razorpayKeyId, razorpayKeySecret);
+            logger.info("Razorpay client initialized successfully.");
+        } catch (RazorpayException e) {
+            logger.error("Error initializing Razorpay client", e);
+            // Application can continue running, but Razorpay transactions will fail.
+            // Or, throw new RuntimeException("Failed to initialize Razorpay client", e); to halt startup.
+        }
+    }
+
     @Override
+    @Transactional
     public PaymentResponse processPayment(PaymentRequest paymentRequest) {
-        // TODO: Implement actual Razorpay payment processing logic
-        System.out.println("Processing payment with Razorpay for amount: " + paymentRequest.getAmount());
-        // Simulate a successful payment
-        PaymentResponse response = new PaymentResponse();
-        response.setTransactionId(UUID.randomUUID().toString());
-        response.setStatus("SUCCESS");
-        response.setMessage("Payment processed successfully by Razorpay.");
-        response.setGatewayName(getGatewayName());
-        return response;
+        if (razorpayClient == null) {
+            logger.error("Razorpay client not initialized. Check API key configuration.");
+            throw new PaymentProcessingException("Razorpay service is not available. Please check configuration.");
+        }
+
+        String internalTransactionId = UUID.randomUUID().toString();
+        Payment payment = new Payment();
+        payment.setTransactionId(internalTransactionId);
+        payment.setAmount(paymentRequest.getAmount());
+        payment.setCurrency(paymentRequest.getCurrency().toUpperCase());
+        payment.setPaymentGateway(getGatewayName());
+        payment.setStatus("PENDING");
+        // @PrePersist will set createdAt and updatedAt
+        payment = paymentRepository.save(payment);
+
+        try {
+            JSONObject orderRequest = new JSONObject();
+            orderRequest.put("amount", paymentRequest.getAmount().multiply(new BigDecimal(100)).intValue()); // Amount in paise
+            orderRequest.put("currency", paymentRequest.getCurrency().toUpperCase());
+            orderRequest.put("receipt", internalTransactionId);
+
+            Order order = razorpayClient.orders.create(orderRequest);
+            String razorpayOrderId = order.get("id");
+            logger.info("Razorpay Order created: {} for internal transaction ID: {}", razorpayOrderId, internalTransactionId);
+
+            // SIMULATION: In a real scenario, client-side handles payment using this order_id.
+            // Then Razorpay sends a webhook or client confirms, providing a `razorpay_payment_id`.
+            // For this backend-only example, we'll simulate capture and use a placeholder payment_id.
+            // This step is crucial: The `gatewayTransactionId` should be the `razorpay_payment_id`.
+            // The `order_id` is just for initiating payment.
+            // If we only have order_id, we can't directly fetch payment status or refund without payment_id.
+
+            // Let's assume for now the order_id is what we store as gatewayTransactionId if no payment_id is obtained server-side.
+            // This is a simplification. Ideally, a webhook updates with actual payment_id.
+            payment.setGatewayTransactionId(razorpayOrderId); // Storing Order ID for now.
+            payment.setStatus("AUTHORIZED"); // Status after order creation, actual payment not yet captured by this backend call.
+                                          // Real status would be PENDING or AWAITING_USER_ACTION.
+                                          // Or if it's a direct server-to-server, it might be different.
+                                          // For Razorpay, 'created' is order status, payment happens after.
+            paymentRepository.save(payment);
+
+            PaymentResponse response = createPaymentResponse(payment, "Razorpay order created. Client must complete payment.", null);
+            response.setRedirectUrl(null); // No redirect URL in this flow yet, but could be if using specific methods
+            // Add razorpay_order_id to gatewaySpecificResponse for client
+            JSONObject specificDetails = new JSONObject();
+            specificDetails.put("razorpay_order_id", razorpayOrderId);
+            response.setGatewaySpecificResponse(specificDetails.toMap());
+            response.setStatus("PENDING_USER_ACTION"); // Custom status indicating client needs to act
+            response.setMessage("Razorpay order created successfully. Please complete the payment using the order_id: " + razorpayOrderId);
+
+
+            return response;
+
+        } catch (RazorpayException e) {
+            logger.error("Razorpay API error during payment processing for transactionId {}: {}", internalTransactionId, e.getMessage(), e);
+            payment.setStatus("FAILED");
+            paymentRepository.save(payment);
+            throw new PaymentProcessingException("Razorpay payment failed: " + e.getMessage(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected error during Razorpay payment processing for transactionId {}: {}", internalTransactionId, e.getMessage(), e);
+            payment.setStatus("ERROR");
+            paymentRepository.save(payment);
+            throw new PaymentProcessingException("Unexpected error during Razorpay payment: " + e.getMessage(), e);
+        }
     }
 
     @Override
+    @Transactional
     public PaymentResponse getPaymentStatus(String transactionId) {
-        // TODO: Implement actual Razorpay get payment status logic
-        System.out.println("Getting payment status from Razorpay for transaction: " + transactionId);
+        // This `transactionId` is OUR internal system's transaction ID.
+        if (razorpayClient == null) {
+            logger.error("Razorpay client not initialized. Check API key configuration.");
+            throw new PaymentProcessingException("Razorpay service is not available. Please check configuration.");
+        }
+        Payment payment = paymentRepository.findByTransactionId(transactionId)
+                .orElseThrow(() -> new PaymentProcessingException("Payment not found with internal transaction ID: " + transactionId));
+
+        // To get actual payment status from Razorpay, we need either:
+        // 1. The Razorpay Payment ID (`razorpay_payment_id`) - preferred.
+        // 2. The Razorpay Order ID (`razorpay_order_id`) - can fetch payments for an order.
+
+        // Current `payment.getGatewayTransactionId()` stores the Order ID from processPayment.
+        String razorpayOrderId = payment.getGatewayTransactionId();
+        if (razorpayOrderId == null || razorpayOrderId.isEmpty()) {
+            logger.warn("Razorpay Order ID is missing for internal transaction ID: {}. Cannot query Razorpay.", transactionId);
+            return createPaymentResponse(payment, "Cannot fetch status from Razorpay: Gateway Order ID is missing.", null);
+        }
+
+        try {
+            // Fetch all payments for the order. There could be multiple attempts.
+            // We'd typically look for a 'captured' one.
+            java.util.List<com.razorpay.Payment> paymentsForOrder = razorpayClient.orders.fetchPayments(razorpayOrderId);
+
+            if (paymentsForOrder.isEmpty()) {
+                // No payment attempts yet or none successful. Order status might be 'created' or 'attempted'.
+                // Fetch order status itself
+                Order order = razorpayClient.orders.fetch(razorpayOrderId);
+                String orderStatus = order.get("status"); // e.g., created, attempted, paid
+                payment.setStatus(mapRazorpayOrderStatusToInternalStatus(orderStatus, null));
+                paymentRepository.save(payment);
+                return createPaymentResponse(payment, "Razorpay order status: " + orderStatus + ". No successful payment captured yet.", razorpayOrderId);
+            }
+
+            // Find a successful payment (captured or authorized)
+            com.razorpay.Payment successfulPayment = null;
+            for (com.razorpay.Payment rzpPayment : paymentsForOrder) {
+                String paymentStatus = rzpPayment.get("status");
+                if ("captured".equalsIgnoreCase(paymentStatus)) {
+                    successfulPayment = rzpPayment;
+                    break;
+                }
+                if (successfulPayment == null && "authorized".equalsIgnoreCase(paymentStatus)) {
+                    successfulPayment = rzpPayment; // Prefer captured, but authorized is also a form of success
+                }
+            }
+
+            if (successfulPayment != null) {
+                String rzpPaymentId = successfulPayment.get("id");
+                String rzpPaymentStatus = successfulPayment.get("status");
+                logger.info("Found Razorpay payment {} with status {} for order {}", rzpPaymentId, rzpPaymentStatus, razorpayOrderId);
+                payment.setGatewayTransactionId(rzpPaymentId); // Update to actual payment_id
+                payment.setStatus(mapRazorpayOrderStatusToInternalStatus(null, rzpPaymentStatus));
+                paymentRepository.save(payment);
+                return createPaymentResponse(payment, "Payment status retrieved successfully from Razorpay: " + rzpPaymentStatus, razorpayOrderId);
+            } else {
+                // No successful payment, update status based on the latest attempt or order status
+                Order order = razorpayClient.orders.fetch(razorpayOrderId); // Re-fetch order for latest overall status
+                String orderStatus = order.get("status");
+                logger.info("No successful (captured/authorized) payment found for order {}. Order status: {}", razorpayOrderId, orderStatus);
+                payment.setStatus(mapRazorpayOrderStatusToInternalStatus(orderStatus, null));
+                paymentRepository.save(payment);
+                return createPaymentResponse(payment, "No successful payment captured for order. Order status: " + orderStatus, razorpayOrderId);
+            }
+
+        } catch (RazorpayException e) {
+            logger.error("Razorpay API error fetching status for order {}: {}", razorpayOrderId, e.getMessage(), e);
+            // Don't change local status based on a fetch failure, just report error
+            throw new PaymentProcessingException("Razorpay status fetch failed for order " + razorpayOrderId + ": " + e.getMessage(), e);
+        }
+    }
+
+
+    @Override
+    @Transactional
+    public PaymentResponse refundPayment(String transactionId, BigDecimal amountToRefund) {
+        // This `transactionId` is OUR internal system's transaction ID.
+         if (razorpayClient == null) {
+            logger.error("Razorpay client not initialized. Check API key configuration.");
+            throw new PaymentProcessingException("Razorpay service is not available. Please check configuration.");
+        }
+        Payment payment = paymentRepository.findByTransactionId(transactionId)
+                .orElseThrow(() -> new PaymentProcessingException("Payment not found for refund with internal transaction ID: " + transactionId));
+
+        // We need the Razorpay Payment ID (not Order ID) to process a refund.
+        // The getPaymentStatus method should have updated gatewayTransactionId to be the payment_id if successful.
+        String razorpayPaymentId = payment.getGatewayTransactionId();
+
+        if (razorpayPaymentId == null || razorpayPaymentId.startsWith("order_")) {
+            // If it's still an order_id, or null, we can't refund.
+            // Attempt to fetch payment status first to get the payment_id.
+            logger.warn("Attempting to fetch payment status to get Razorpay Payment ID before refund for internal transaction ID: {}", transactionId);
+            getPaymentStatus(transactionId); // This will attempt to update payment.gatewayTransactionId
+            payment = paymentRepository.findByTransactionId(transactionId).get(); // Re-fetch
+            razorpayPaymentId = payment.getGatewayTransactionId();
+            if (razorpayPaymentId == null || razorpayPaymentId.startsWith("order_")) {
+                 throw new PaymentProcessingException("Cannot refund: Razorpay Payment ID not found for " + transactionId + ". Please check payment status first.");
+            }
+        }
+
+        if (!"SUCCESS".equalsIgnoreCase(payment.getStatus()) && !"CAPTURED".equalsIgnoreCase(payment.getStatus())) { // CAPTURED is Razorpay's term for successful
+             throw new PaymentProcessingException("Cannot refund: Payment " + transactionId + " (Razorpay ID: "+razorpayPaymentId+") is not in a refundable state (current status: " + payment.getStatus() + ")");
+        }
+
+        try {
+            JSONObject refundRequest = new JSONObject();
+            refundRequest.put("amount", amountToRefund.multiply(new BigDecimal(100)).intValue()); // Amount in paise
+            // Optional: notes, speed, receipt for refund
+            // refundRequest.put("speed", "normal"); // "normal" or "optimum"
+
+            Refund refund = razorpayClient.payments.refund(razorpayPaymentId, refundRequest);
+            String refundId = refund.get("id");
+            String refundStatus = refund.get("status"); // e.g., pending, processed
+            logger.info("Razorpay refund initiated for payment {}. Refund ID: {}, Status: {}", razorpayPaymentId, refundId, refundStatus);
+
+            // Update our payment status based on refund.
+            // If a refund is "processed" or "pending" (accepted by Razorpay), we mark as REFUNDED.
+            // A more granular system might track partial refunds or use a status like "PARTIALLY_REFUNDED".
+            if ("processed".equalsIgnoreCase(refundStatus) || "pending".equalsIgnoreCase(refundStatus)) {
+                payment.setStatus("REFUNDED"); // Or "PARTIALLY_REFUNDED" if you track amounts
+            } else {
+                // if refund fails immediately, this path might be taken.
+                // However, usually it goes to pending then processed or failed via webhooks.
+                payment.setStatus("REFUND_FAILED");
+            }
+            paymentRepository.save(payment);
+
+            PaymentResponse response = createPaymentResponse(payment, "Refund request processed by Razorpay. Current refund status: " + refundStatus, null); // No order_id needed here typically
+            response.setGatewaySpecificResponse(refund.toJson().toMap());
+            return response;
+
+        } catch (RazorpayException e) {
+            logger.error("Razorpay API error during refund for payment {}: {}", razorpayPaymentId, e.getMessage(), e);
+            payment.setStatus("REFUND_FAILED"); // Keep our internal status reflective
+            paymentRepository.save(payment);
+            throw new PaymentProcessingException("Razorpay refund failed for payment " + razorpayPaymentId + ": " + e.getMessage(), e);
+        }
+    }
+
+    private PaymentResponse createPaymentResponse(Payment payment, String message, String razorpayOrderId) {
         PaymentResponse response = new PaymentResponse();
-        response.setTransactionId(transactionId);
-        response.setStatus("SUCCESS"); // Simulate as success for now
-        response.setMessage("Payment status retrieved successfully from Razorpay.");
+        response.setTransactionId(payment.getTransactionId()); // Our internal ID
+        response.setGatewayTransactionId(payment.getGatewayTransactionId()); // Razorpay Payment ID or Order ID
+        response.setStatus(payment.getStatus());
+        response.setMessage(message);
         response.setGatewayName(getGatewayName());
+        response.setAmount(payment.getAmount());
+        response.setCurrency(payment.getCurrency());
+        response.setTimestamp(payment.getUpdatedAt());
+
+        JSONObject specificDetails = new JSONObject();
+        if (razorpayOrderId != null) {
+            specificDetails.put("razorpay_order_id", razorpayOrderId);
+        }
+        // If gatewayTransactionId is the payment_id, include it clearly
+        if (payment.getGatewayTransactionId() != null && payment.getGatewayTransactionId().startsWith("pay_")) {
+            specificDetails.put("razorpay_payment_id", payment.getGatewayTransactionId());
+        }
+        if (!specificDetails.isEmpty()) {
+            response.setGatewaySpecificResponse(specificDetails.toMap());
+        }
         return response;
     }
 
-    @Override
-    public PaymentResponse refundPayment(String transactionId, BigDecimal amount) {
-        // TODO: Implement actual Razorpay refund logic
-        System.out.println("Processing refund with Razorpay for transaction: " + transactionId + " for amount: " + amount);
-        PaymentResponse response = new PaymentResponse();
-        response.setTransactionId(transactionId);
-        response.setStatus("REFUND_SUCCESS");
-        response.setMessage("Refund processed successfully by Razorpay.");
-        response.setGatewayName(getGatewayName());
-        return response;
+    // Maps Razorpay's order status or payment status to our internal system status
+    private String mapRazorpayOrderStatusToInternalStatus(String orderStatus, String paymentStatus) {
+        if (paymentStatus != null) { // Payment status takes precedence
+            switch (paymentStatus.toLowerCase()) {
+                case "created": return "PENDING"; // Payment link created, user hasn't acted
+                case "authorized": return "AUTHORIZED";
+                case "captured": return "SUCCESS";
+                case "failed": return "FAILED";
+                case "refunded": return "REFUNDED"; // This is for full refund on payment object
+                default: return paymentStatus.toUpperCase();
+            }
+        }
+        if (orderStatus != null) { // Fallback to order status
+            switch (orderStatus.toLowerCase()) {
+                case "created": return "PENDING_USER_ACTION"; // Order created, waiting for user
+                case "attempted": return "PENDING"; // User attempted, might succeed or fail
+                case "paid": return "SUCCESS"; // Order is marked paid (all payments captured)
+                default: return orderStatus.toUpperCase();
+            }
+        }
+        return "UNKNOWN";
     }
+
 
     @Override
     public String getGatewayName() {

--- a/src/main/java/com/example/multipaymentgateway/service/StripeService.java
+++ b/src/main/java/com/example/multipaymentgateway/service/StripeService.java
@@ -2,49 +2,282 @@ package com.example.multipaymentgateway.service;
 
 import com.example.multipaymentgateway.dto.PaymentRequest;
 import com.example.multipaymentgateway.dto.PaymentResponse;
+import com.example.multipaymentgateway.exception.PaymentProcessingException;
+import com.example.multipaymentgateway.model.Payment;
+import com.example.multipaymentgateway.repository.PaymentRepository;
+import com.stripe.Stripe;
+import com.stripe.exception.StripeException;
+import com.stripe.model.PaymentIntent;
+import com.stripe.model.Refund;
+import com.stripe.param.PaymentIntentCreateParams;
+import com.stripe.param.RefundCreateParams;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 @Service("stripeService")
 public class StripeService implements PaymentGateway {
 
+    private static final Logger logger = LoggerFactory.getLogger(StripeService.class);
+
+    @Value("${stripe.secret.key}")
+    private String stripeSecretKey;
+
+    private final PaymentRepository paymentRepository;
+    private boolean stripeInitialized = false;
+
+    public StripeService(PaymentRepository paymentRepository) {
+        this.paymentRepository = paymentRepository;
+    }
+
+    @PostConstruct
+    public void init() {
+        if (stripeSecretKey == null || stripeSecretKey.isEmpty() || stripeSecretKey.equals("sk_test_YOUR_STRIPE_SECRET_KEY") || stripeSecretKey.equals("YOUR_STRIPE_SECRET_KEY")) {
+            logger.warn("Stripe API Key is not configured or using default placeholder. Stripe client will not be initialized.");
+            return;
+        }
+        Stripe.apiKey = stripeSecretKey;
+        stripeInitialized = true;
+        logger.info("Stripe client initialized successfully.");
+    }
+
     @Override
+    @Transactional
     public PaymentResponse processPayment(PaymentRequest paymentRequest) {
-        // TODO: Implement actual Stripe payment processing logic
-        System.out.println("Processing payment with Stripe for amount: " + paymentRequest.getAmount());
-        // Simulate a successful payment
-        PaymentResponse response = new PaymentResponse();
-        response.setTransactionId(UUID.randomUUID().toString());
-        response.setStatus("SUCCESS");
-        response.setMessage("Payment processed successfully by Stripe.");
-        response.setGatewayName(getGatewayName());
-        return response;
+        if (!stripeInitialized) {
+            logger.error("Stripe client not initialized. Check API key configuration.");
+            throw new PaymentProcessingException("Stripe service is not available. Please check configuration.");
+        }
+
+        String internalTransactionId = UUID.randomUUID().toString();
+        Payment payment = new Payment();
+        payment.setTransactionId(internalTransactionId);
+        payment.setAmount(paymentRequest.getAmount());
+        payment.setCurrency(paymentRequest.getCurrency().toLowerCase()); // Stripe expects lowercase currency
+        payment.setPaymentGateway(getGatewayName());
+        payment.setStatus("PENDING");
+        payment = paymentRepository.save(payment);
+
+        try {
+            PaymentIntentCreateParams.Builder paramsBuilder =
+                PaymentIntentCreateParams.builder()
+                    .setAmount(paymentRequest.getAmount().multiply(new BigDecimal(100)).longValue()) // Amount in cents
+                    .setCurrency(paymentRequest.getCurrency().toLowerCase())
+                    .setConfirmationMethod(PaymentIntentCreateParams.ConfirmationMethod.AUTOMATIC) // Or MANUAL
+                    .setConfirm(true); // Attempt to confirm the PaymentIntent immediately.
+                                       // Requires a payment method.
+
+            // For this server-side flow, we'd typically use `payment_method_types` and then handle client-side confirmation.
+            // Or, if a payment_method_id is passed from client: paramsBuilder.setPaymentMethod("pm_card_visa");
+            // To make this runnable without client-side, we can use a test payment method if available
+            // or rely on a flow where payment_method is attached later.
+            // For now, let's use automatic payment methods if enabled in Stripe dashboard, or a test card.
+            // This example assumes you might pass a payment method ID from the request or use automatic_payment_methods.
+            // If paymentRequest.getPaymentMethodId() is available:
+            // paramsBuilder.setPaymentMethod(paymentRequest.getPaymentMethodId());
+            // else, rely on automatic_payment_methods or default test cards for this example.
+            // For a simple charge (not recommended for new integrations, use PaymentIntents):
+            // ChargeCreateParams chargeParams = ChargeCreateParams.builder()...
+
+            // Using a common test payment method for off-session/server-initiated like behavior
+            // This is for testing and might not work for all scenarios or live mode without proper setup.
+            // In real scenario: the client would provide a PaymentMethod ID (e.g., "pm_card_visa")
+            // which you would include here.
+             if (paymentRequest.getPaymentMethodId() != null && !paymentRequest.getPaymentMethodId().isBlank()){
+                 paramsBuilder.setPaymentMethod(paymentRequest.getPaymentMethodId());
+             } else {
+                 // If no payment method ID is provided, this PaymentIntent will be created
+                 // but will require client-side action to confirm with a payment method.
+                 // For testing, sometimes Stripe allows confirming without a PM if you have a default test source
+                 // or if you are using specific test card numbers that don't require a full PM object.
+                 // However, the robust way is to get a PM from the client.
+                 // For this example, let's assume the intent is created and needs client action.
+                 // We will not setConfirm(true) if no payment method is provided.
+                 paramsBuilder.setConfirm(false); // Create the intent, client will confirm
+                 paramsBuilder.addPaymentMethodType("card"); // Specify acceptable payment types
+             }
+
+
+            PaymentIntent paymentIntent = PaymentIntent.create(paramsBuilder.build());
+            logger.info("Stripe PaymentIntent created: {} for internal transaction ID: {}", paymentIntent.getId(), internalTransactionId);
+
+            payment.setGatewayTransactionId(paymentIntent.getId());
+            payment.setStatus(mapStripePaymentIntentStatus(paymentIntent.getStatus()));
+            paymentRepository.save(payment);
+
+            PaymentResponse response = createPaymentResponse(payment, "Stripe PaymentIntent created. Status: " + paymentIntent.getStatus(), paymentIntent.getClientSecret());
+
+            // If requires_action or requires_confirmation, client_secret is needed by the client.
+            if ("requires_action".equals(paymentIntent.getStatus()) || "requires_confirmation".equals(paymentIntent.getStatus()) || "requires_payment_method".equals(paymentIntent.getStatus())) {
+                response.setRedirectUrl(null); // No specific redirect URL, client uses client_secret with Stripe.js
+                response.setStatus("PENDING_USER_ACTION");
+                Map<String, Object> gatewaySpecific = new HashMap<>();
+                gatewaySpecific.put("stripe_payment_intent_id", paymentIntent.getId());
+                gatewaySpecific.put("stripe_client_secret", paymentIntent.getClientSecret());
+                response.setGatewaySpecificResponse(gatewaySpecific);
+                 response.setMessage("Stripe PaymentIntent created. Client action required using client_secret.");
+            } else if ("succeeded".equals(paymentIntent.getStatus())) {
+                 response.setMessage("Stripe payment processed successfully.");
+            }
+
+
+            return response;
+
+        } catch (StripeException e) {
+            logger.error("Stripe API error during payment processing for transactionId {}: {} - {}", internalTransactionId, e.getCode(), e.getMessage(), e);
+            payment.setStatus("FAILED");
+            paymentRepository.save(payment);
+            throw new PaymentProcessingException("Stripe payment failed: " + e.getMessage(), e);
+        } catch (Exception e) {
+            logger.error("Unexpected error during Stripe payment processing for transactionId {}: {}", internalTransactionId, e.getMessage(), e);
+            payment.setStatus("ERROR");
+            paymentRepository.save(payment);
+            throw new PaymentProcessingException("Unexpected error during Stripe payment: " + e.getMessage(), e);
+        }
     }
 
     @Override
+    @Transactional
     public PaymentResponse getPaymentStatus(String transactionId) {
-        // TODO: Implement actual Stripe get payment status logic
-        System.out.println("Getting payment status from Stripe for transaction: " + transactionId);
-        PaymentResponse response = new PaymentResponse();
-        response.setTransactionId(transactionId);
-        response.setStatus("SUCCESS"); // Simulate as success for now
-        response.setMessage("Payment status retrieved successfully from Stripe.");
-        response.setGatewayName(getGatewayName());
-        return response;
+        // This `transactionId` is OUR internal system's transaction ID.
+        if (!stripeInitialized) {
+            logger.error("Stripe client not initialized. Check API key configuration.");
+            throw new PaymentProcessingException("Stripe service is not available. Please check configuration.");
+        }
+        Payment payment = paymentRepository.findByTransactionId(transactionId)
+                .orElseThrow(() -> new PaymentProcessingException("Payment not found with internal transaction ID: " + transactionId));
+
+        String stripePaymentIntentId = payment.getGatewayTransactionId();
+        if (stripePaymentIntentId == null || stripePaymentIntentId.isEmpty()) {
+            logger.warn("Stripe PaymentIntent ID is missing for internal transaction ID: {}. Cannot query Stripe.", transactionId);
+            return createPaymentResponse(payment, "Cannot fetch status from Stripe: Gateway Transaction ID (PaymentIntent ID) is missing.", null);
+        }
+
+        try {
+            PaymentIntent paymentIntent = PaymentIntent.retrieve(stripePaymentIntentId);
+            String stripeStatus = paymentIntent.getStatus();
+            logger.info("Stripe PaymentIntent {} status: {}", stripePaymentIntentId, stripeStatus);
+
+            payment.setStatus(mapStripePaymentIntentStatus(stripeStatus));
+            // Update amount if it can change (e.g. for some payment methods or if not set initially from intent)
+            // payment.setAmount(new BigDecimal(paymentIntent.getAmountReceived()).divide(new BigDecimal(100)));
+            paymentRepository.save(payment);
+
+            return createPaymentResponse(payment, "Payment status retrieved successfully from Stripe: " + stripeStatus, paymentIntent.getClientSecret());
+
+        } catch (StripeException e) {
+            logger.error("Stripe API error fetching status for PaymentIntent {}: {}", stripePaymentIntentId, e.getMessage(), e);
+            throw new PaymentProcessingException("Stripe status fetch failed for " + stripePaymentIntentId + ": " + e.getMessage(), e);
+        }
     }
 
     @Override
-    public PaymentResponse refundPayment(String transactionId, BigDecimal amount) {
-        // TODO: Implement actual Stripe refund logic
-        System.out.println("Processing refund with Stripe for transaction: " + transactionId + " for amount: " + amount);
+    @Transactional
+    public PaymentResponse refundPayment(String transactionId, BigDecimal amountToRefund) {
+        // This `transactionId` is OUR internal system's transaction ID.
+        if (!stripeInitialized) {
+            logger.error("Stripe client not initialized. Check API key configuration.");
+            throw new PaymentProcessingException("Stripe service is not available. Please check configuration.");
+        }
+        Payment payment = paymentRepository.findByTransactionId(transactionId)
+                .orElseThrow(() -> new PaymentProcessingException("Payment not found for refund with internal transaction ID: " + transactionId));
+
+        String stripePaymentIntentId = payment.getGatewayTransactionId();
+        if (stripePaymentIntentId == null || stripePaymentIntentId.isEmpty()) {
+            throw new PaymentProcessingException("Cannot refund: Stripe PaymentIntent ID is missing for " + transactionId);
+        }
+
+        // Stripe refunds are against a Charge ID or PaymentIntent ID.
+        // If status is not "succeeded", it might not be refundable.
+        if (!"SUCCESS".equalsIgnoreCase(payment.getStatus())) { // Our internal status
+             // We could also check Stripe's status directly if needed: getPaymentStatus(transactionId); payment = ...
+             throw new PaymentProcessingException("Cannot refund: Payment " + transactionId + " (Stripe PI: "+stripePaymentIntentId+") is not in a refundable state (current status: " + payment.getStatus() + ")");
+        }
+
+        try {
+            RefundCreateParams.Builder refundParamsBuilder = RefundCreateParams.builder()
+                .setPaymentIntent(stripePaymentIntentId);
+
+            if (amountToRefund != null && amountToRefund.compareTo(BigDecimal.ZERO) > 0 && amountToRefund.compareTo(payment.getAmount()) <= 0) {
+                refundParamsBuilder.setAmount(amountToRefund.multiply(new BigDecimal(100)).longValue());
+            } // If amountToRefund is null or zero, Stripe will attempt a full refund.
+
+            Refund refund = Refund.create(refundParamsBuilder.build());
+            String refundId = refund.getId();
+            String refundStatus = refund.getStatus(); // e.g., succeeded, pending, failed, canceled
+            logger.info("Stripe refund initiated for PaymentIntent {}. Refund ID: {}, Status: {}", stripePaymentIntentId, refundId, refundStatus);
+
+            // Update our payment status
+            if ("succeeded".equalsIgnoreCase(refundStatus) || "pending".equalsIgnoreCase(refundStatus)) {
+                // Check if it's a partial refund
+                if (amountToRefund != null && payment.getAmount().compareTo(amountToRefund) > 0 && "succeeded".equalsIgnoreCase(refundStatus)) {
+                    payment.setStatus("PARTIALLY_REFUNDED");
+                } else {
+                    payment.setStatus("REFUNDED");
+                }
+            } else {
+                payment.setStatus("REFUND_FAILED");
+            }
+            paymentRepository.save(payment);
+
+            PaymentResponse response = createPaymentResponse(payment, "Refund request processed by Stripe. Current refund status: " + refundStatus, null);
+            response.setGatewaySpecificResponse(refund.toJson()); // Convert Stripe object to map/json string
+            return response;
+
+        } catch (StripeException e) {
+            logger.error("Stripe API error during refund for PaymentIntent {}: {}", stripePaymentIntentId, e.getMessage(), e);
+            payment.setStatus("REFUND_FAILED");
+            paymentRepository.save(payment);
+            throw new PaymentProcessingException("Stripe refund failed for " + stripePaymentIntentId + ": " + e.getMessage(), e);
+        }
+    }
+
+    private PaymentResponse createPaymentResponse(Payment payment, String message, String clientSecret) {
         PaymentResponse response = new PaymentResponse();
-        response.setTransactionId(transactionId);
-        response.setStatus("REFUND_SUCCESS");
-        response.setMessage("Refund processed successfully by Stripe.");
+        response.setTransactionId(payment.getTransactionId());
+        response.setGatewayTransactionId(payment.getGatewayTransactionId()); // Stripe PaymentIntent ID
+        response.setStatus(payment.getStatus());
+        response.setMessage(message);
         response.setGatewayName(getGatewayName());
+        response.setAmount(payment.getAmount());
+        response.setCurrency(payment.getCurrency());
+        response.setTimestamp(payment.getUpdatedAt());
+
+        Map<String, Object> specificDetails = new HashMap<>();
+        specificDetails.put("stripe_payment_intent_id", payment.getGatewayTransactionId());
+        if (clientSecret != null && !clientSecret.isEmpty()) {
+            specificDetails.put("stripe_client_secret", clientSecret);
+        }
+        response.setGatewaySpecificResponse(specificDetails);
         return response;
+    }
+
+    private String mapStripePaymentIntentStatus(String stripeStatus) {
+        if (stripeStatus == null) return "UNKNOWN";
+        switch (stripeStatus.toLowerCase()) {
+            case "requires_payment_method":
+            case "requires_confirmation":
+            case "requires_action":
+            case "processing":
+                return "PENDING"; // Or more specific if needed, e.g. PENDING_USER_ACTION
+            case "succeeded":
+                return "SUCCESS";
+            case "canceled":
+                return "CANCELED";
+            case "requires_capture": // Relevant if using manual capture
+                return "AUTHORIZED";
+            default:
+                logger.warn("Unknown Stripe PaymentIntent status: {}", stripeStatus);
+                return stripeStatus.toUpperCase(); // Or FAILED as a fallback
+        }
     }
 
     @Override

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,8 +21,8 @@ razorpay.api.secret=YOUR_RAZORPAY_KEY_SECRET
 # razorpay.webhook.secret=YOUR_RAZORPAY_WEBHOOK_SECRET
 
 # Stripe Configuration
-stripe.api.key=YOUR_STRIPE_PUBLISHABLE_KEY
-stripe.api.secret=YOUR_STRIPE_SECRET_KEY
+# For server-side operations, Stripe typically uses a single secret key.
+stripe.secret.key=sk_test_YOUR_STRIPE_SECRET_KEY # Replace with your actual Stripe secret key
 # stripe.webhook.secret=YOUR_STRIPE_WEBHOOK_SECRET
 
 # Finix Configuration (Example - if you were to add Finix)


### PR DESCRIPTION
Implemented actual API integrations for Razorpay and Stripe payment gateways, replacing stub implementations.

Key changes include:
- Created `Payment` entity and `PaymentRepository` for persisting payment transaction details.
- Added Razorpay and Stripe SDK dependencies to `pom.xml`.
- Configured placeholders for API keys in `application.properties`.
- Implemented `RazorpayService`:
    - Handles payment processing by creating Razorpay Orders. Client-side interaction is expected to complete the payment using the order_id.
    - Fetches payment status by Order ID, retrieving associated payment details and updating the local Payment entity with the Razorpay Payment ID upon success.
    - Processes refunds against Razorpay Payment IDs.
- Implemented `StripeService`:
    - Handles payment processing using Stripe PaymentIntents. Supports scenarios requiring client-side confirmation by returning a client_secret.
    - Fetches PaymentIntent status and updates the local Payment entity.
    - Processes refunds against Stripe PaymentIntent IDs.
- Both services now create and update `Payment` entities in the database, mapping gateway responses to `PaymentResponse` DTOs and handling common API error conditions.
- Ensured `PaymentResponse` DTO is adequate for conveying necessary information.